### PR TITLE
Removed spaces from places search

### DIFF
--- a/server/backendAPI/google_places_curl.php
+++ b/server/backendAPI/google_places_curl.php
@@ -1,6 +1,7 @@
 <?php
 
 $place = $_GET['data'];
+$place = str_replace(' ','', $place);
 
 $curl = curl_init();
 


### PR DESCRIPTION
Previously, the places search would not work for cities with spaces like San Diego and Los Angeles. It works now.